### PR TITLE
Add zpq_buffered_rx() to ZpqStream

### DIFF
--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -1487,7 +1487,7 @@ internal_flush(void)
 	char	   *bufptr = PqSendBuffer + PqSendStart;
 	char	   *bufend = PqSendBuffer + PqSendPointer;
 
-	while (bufptr < bufend || zpq_buffered(PqStream) != 0)
+	while (bufptr < bufend || zpq_buffered_tx(PqStream) != 0)
     /* has more data to flush or unsent data in internal compression buffer */
 	{
 		int		r;

--- a/src/include/common/zpq_stream.h
+++ b/src/include/common/zpq_stream.h
@@ -23,7 +23,8 @@ ZpqStream* zpq_create(int impl, zpq_tx_func tx_func, zpq_rx_func rx_func, void* 
 ssize_t zpq_read(ZpqStream* zs, void* buf, size_t size);
 ssize_t zpq_write(ZpqStream* zs, void const* buf, size_t size, size_t* processed);
 char const* zpq_error(ZpqStream* zs);
-size_t zpq_buffered(ZpqStream* zs);
+size_t zpq_buffered_tx(ZpqStream* zs);
+size_t zpq_buffered_rx(ZpqStream* zs);
 void zpq_free(ZpqStream* zs);
 
 void zpq_get_supported_algorithms(char algorithms[ZPQ_MAX_ALGORITHMS]);

--- a/src/interfaces/libpq/fe-misc.c
+++ b/src/interfaces/libpq/fe-misc.c
@@ -899,7 +899,7 @@ pqSendSome(PGconn *conn, int len)
 	}
 
 	/* while there's still data to send */
-	while (len > 0 || zpq_buffered(conn->zstream))
+	while (len > 0 || zpq_buffered_tx(conn->zstream))
 	{
 		int			sent;
 		size_t      processed = 0;
@@ -972,7 +972,7 @@ pqSendSome(PGconn *conn, int len)
 			remaining -= sent;
 		}
 
-		if (len > 0 || sent < 0 || zpq_buffered(conn->zstream))
+		if (len > 0 || sent < 0 || zpq_buffered_tx(conn->zstream))
 		{
 			/*
 			 * We didn't send it all, wait till we can send more.


### PR DESCRIPTION
In this PR I propose implementing the zpq_buffered_rx().

zpq_buffered_rx() returns a value greater than zero if there is any data that was fetched by rx_func() but haven't been decompressed yet, in any other case zpq_buffered_rx() returns zero.

Also, I propose renaming the existing zpq_buffered() to zpq_buffered_tx() for clarity.