### PR TITLE
Fix replication issues

### DIFF
--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -1564,7 +1564,7 @@ socket_flush_if_writable(void)
 	int			res;
 
 	/* Quick exit if nothing to do */
-	if (PqSendPointer == PqSendStart)
+	if ((PqSendPointer == PqSendStart) && (zpq_buffered_tx(PqStream) == 0))
 		return 0;
 
 	/* No-op if reentrant call */
@@ -1587,7 +1587,7 @@ socket_flush_if_writable(void)
 static bool
 socket_is_send_pending(void)
 {
-	return (PqSendStart < PqSendPointer);
+	return (PqSendStart < PqSendPointer || (zpq_buffered_tx(PqStream) != 0));
 }
 
 /* --------------------------------

--- a/src/common/zpq_stream.c
+++ b/src/common/zpq_stream.c
@@ -209,7 +209,8 @@ zstd_write(ZpqStream *zstream, void const *buf, size_t size, size_t *processed)
 			zs->tx_total_raw += in_buf.pos;
 			return rc;
 		}
-	} while (zs->tx.pos == 0 && (in_buf.pos < size || zs->tx_not_flushed)); /* repeat sending data until first partial write */
+    /* repeat sending while there is some data in input or internal zstd buffer */
+    } while (in_buf.pos < size || zs->tx_not_flushed);
 
 	zs->tx_total_raw += in_buf.pos;
 	zs->tx_buffered = zs->tx.pos;

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2157,6 +2157,12 @@ connectDBComplete(PGconn *conn)
 				return 1;		/* success! */
 
 			case PGRES_POLLING_READING:
+			    /* if there is some buffered RX data in ZpqStream
+			     * then don't proceed to pqWaitTimed */
+			    if (zpq_buffered_rx(conn->zstream)) {
+			        break;
+			    }
+
 				ret = pqWaitTimed(1, 0, conn, finish_time);
 				if (ret == -1)
 				{


### PR DESCRIPTION
I removed the check on partial write from both ZSTD and ZLIB implementations because it led to a bug when the socket write function could not consume the entire tx buffer resulting in breaking the zstd/zlib_write main loop too soon. 

Also, there was a problem with the internal ZLIB buffer - there could be a situation when there was some data left in it and there was no way to check it. It sometimes caused the hang of the replication process. So I added the tx_deflate_pending field to represent the current state of the internal ZLIB buffer.

Also, I've added some more checks for buffered_rx and buffered_tx data for both frontend and backend code.