### PR TITLE
Implement selective compression

### DIFF
--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -245,7 +245,7 @@ pq_configure(Port *port)
 	{
 		int			compression_level = ZPQ_DEFAULT_COMPRESSION_LEVEL;
 		int			impl = -1;
-		char	  **server_compression_algorithms = zpq_get_supported_algorithms();
+		char	  **server_compression_algorithms = zs_get_supported_algorithms();
 		int			index = -1;
 		char	   *protocol_extension = strchr(client_compression_algorithms, ';');
 
@@ -289,7 +289,8 @@ SendCompressionAck:
 
 		if (index >= 0)			/* Use compression */
 		{
-			PqStream = zpq_create(impl, compression_level, impl, write_compressed, read_compressed, MyProcPort, NULL, 0);
+			PqStream = zpq_create(impl, compression_level, impl, write_compressed, read_compressed, MyProcPort,
+								  NULL, 0);
 			if (!PqStream)
 			{
 				ereport(LOG,
@@ -1080,7 +1081,7 @@ pq_recvbuf(bool nowait)
 
 		if (r < 0)
 		{
-			if (r == ZPQ_DECOMPRESS_ERROR)
+			if (r == ZS_DECOMPRESS_ERROR)
 			{
 				char const *msg = zpq_decompress_error(PqStream);
 

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -6299,6 +6299,9 @@ threadRun(void *arg)
 		int			nsocks;		/* number of sockets to be waited for */
 		int64		min_usec;
 		int64		now_usec = 0;	/* set this only if needed */
+		bool		buffered_rx = false;	/* true if some of the clients has
+											 * data left in SSL/ZPQ read
+											 * buffers */
 
 		/*
 		 * identify which client sockets should be checked for input, and
@@ -6338,6 +6341,9 @@ threadRun(void *arg)
 				 * socket is readable
 				 */
 				int			sock = PQsocket(st->con);
+
+				/* check if conn has buffered SSL / ZPQ read data */
+				buffered_rx = buffered_rx || PQreadPending(st->con);
 
 				if (sock < 0)
 				{
@@ -6389,7 +6395,7 @@ threadRun(void *arg)
 			{
 				if (nsocks > 0)
 				{
-					rc = wait_on_socket_set(sockets, min_usec);
+					rc = buffered_rx ? 1 : wait_on_socket_set(sockets, min_usec);
 				}
 				else			/* nothing active, simple sleep */
 				{
@@ -6398,7 +6404,7 @@ threadRun(void *arg)
 			}
 			else				/* no explicit delay, wait without timeout */
 			{
-				rc = wait_on_socket_set(sockets, 0);
+				rc = buffered_rx ? 1 : wait_on_socket_set(sockets, 0);
 			}
 
 			if (rc < 0)
@@ -6437,8 +6443,11 @@ threadRun(void *arg)
 					pg_log_error("invalid socket: %s", PQerrorMessage(st->con));
 					goto done;
 				}
-
-				if (!socket_has_input(sockets, sock, nsocks++))
+				if (PQreadPending(st->con))
+				{
+					nsocks++;
+				}
+				else if (!socket_has_input(sockets, sock, nsocks++))
 					continue;
 			}
 			else if (st->state == CSTATE_FINISHED ||

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -78,6 +78,7 @@ OBJS_COMMON = \
 	username.o \
 	wait_error.o \
 	wchar.o \
+	z_stream.o \
 	zpq_stream.o
 
 ifeq ($(with_openssl),yes)

--- a/src/common/z_stream.c
+++ b/src/common/z_stream.c
@@ -1,0 +1,666 @@
+#include "c.h"
+#include "pg_config.h"
+#include "common/z_stream.h"
+
+/*
+ * Functions implementing streaming compression algorithm
+ */
+typedef struct
+{
+	/*
+	 * Name of compression algorithm.
+	 */
+	char const *(*name) (void);
+
+	/*
+	 * Create new compression stream. level: compression level
+	 */
+	void	   *(*create_compressor) (int level);
+
+	/*
+	 * Create new decompression stream.
+	 */
+	void	   *(*create_decompressor) ();
+
+	/*
+	 * Decompress up to "src_size" compressed bytes from *src and write up to
+	 * "dst_size" raw (decompressed) bytes to *dst. Number of decompressed
+	 * bytes written to *dst is stored in *dst_processed. Number of compressed
+	 * bytes read from *src is stored in *src_processed.
+	 *
+	 * Return codes: ZS_OK if no errors were encountered during decompression
+	 * attempt. This return code does not guarantee that *src_processed > 0 or
+	 * *dst_processed > 0.
+	 *
+	 * ZS_DATA_PENDING means that there might be some data left within
+	 * decompressor internal buffers.
+	 *
+	 * ZS_STREAM_END if encountered end of compressed data stream.
+	 *
+	 * ZS_DECOMPRESS_ERROR if encountered an error during decompression
+	 * attempt.
+	 */
+	ssize_t		(*decompress) (void *ds, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed);
+
+	/*
+	 * Compress up to "src_size" raw (non-compressed) bytes from *src and
+	 * write up to "dst_size" compressed bytes to *dst. Number of compressed
+	 * bytes written to *dst is stored in *dst_processed. Number of
+	 * non-compressed bytes read from *src is stored in *src_processed.
+	 *
+	 * Return codes: ZS_OK if no errors were encountered during compression
+	 * attempt. This return code does not guarantee that *src_processed > 0 or
+	 * *dst_processed > 0.
+	 *
+	 * ZS_DATA_PENDING means that there might be some data left within
+	 * compressor internal buffers.
+	 *
+	 * ZS_COMPRESS_ERROR if encountered an error during compression attempt.
+	 */
+	ssize_t		(*compress) (void *cs, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed);
+
+	/*
+	 * Free compression stream created by create_compressor function.
+	 */
+	void		(*free_compressor) (void *cs);
+
+	/*
+	 * Free decompression stream created by create_decompressor function.
+	 */
+	void		(*free_decompressor) (void *ds);
+
+	/*
+	 * Get compressor error message.
+	 */
+	char const *(*compress_error) (void *cs);
+
+	/*
+	 * Get decompressor error message.
+	 */
+	char const *(*decompress_error) (void *ds);
+
+	ssize_t		(*end_compression) (void *cs, void *dst, size_t dst_size, size_t *dst_processed);
+}			ZAlgorithm;
+
+struct ZStream
+{
+	ZAlgorithm const *c_algorithm;
+	void	   *c_stream;
+
+	ZAlgorithm const *d_algorithm;
+	void	   *d_stream;
+
+	bool		rx_not_flushed;
+	bool		tx_not_flushed;
+};
+
+#if HAVE_LIBZSTD
+
+#include <stdlib.h>
+#include <zstd.h>
+
+/*
+ * Maximum allowed back-reference distance, expressed as power of 2.
+ * This setting controls max compressor/decompressor window size.
+ * More details https://github.com/facebook/zstd/blob/v1.4.7/lib/zstd.h#L536
+ */
+#define ZSTD_WINDOWLOG_LIMIT 23 /* set max window size to 8MB */
+
+
+typedef struct ZPQ_ZSTD_CStream
+{
+	ZSTD_CStream *stream;
+	char const *error;			/* error message */
+}			ZPQ_ZSTD_CStream;
+
+typedef struct ZPQ_ZSTD_DStream
+{
+	ZSTD_DStream *stream;
+	char const *error;			/* error message */
+}			ZPQ_ZSTD_DStream;
+
+static void *
+zstd_create_compressor(int level)
+{
+	ZPQ_ZSTD_CStream *c_stream = (ZPQ_ZSTD_CStream *) malloc(sizeof(ZPQ_ZSTD_CStream));
+
+	c_stream->stream = ZSTD_createCStream();
+	ZSTD_initCStream(c_stream->stream, level);
+#if ZSTD_VERSION_MAJOR > 1 || ZSTD_VERSION_MINOR > 3
+	ZSTD_CCtx_setParameter(c_stream->stream, ZSTD_c_windowLog, ZSTD_WINDOWLOG_LIMIT);
+#endif
+	c_stream->error = NULL;
+	return c_stream;
+}
+
+static void *
+zstd_create_decompressor()
+{
+	ZPQ_ZSTD_DStream *d_stream = (ZPQ_ZSTD_DStream *) malloc(sizeof(ZPQ_ZSTD_DStream));
+
+	d_stream->stream = ZSTD_createDStream();
+	ZSTD_initDStream(d_stream->stream);
+#if ZSTD_VERSION_MAJOR > 1 || ZSTD_VERSION_MINOR > 3
+	ZSTD_DCtx_setParameter(d_stream->stream, ZSTD_d_windowLogMax, ZSTD_WINDOWLOG_LIMIT);
+#endif
+	d_stream->error = NULL;
+	return d_stream;
+}
+
+static ssize_t
+zstd_decompress(void *d_stream, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	ZPQ_ZSTD_DStream *ds = (ZPQ_ZSTD_DStream *) d_stream;
+	ZSTD_inBuffer in;
+	ZSTD_outBuffer out;
+	size_t		rc;
+
+	in.src = src;
+	in.pos = 0;
+	in.size = src_size;
+
+	out.dst = dst;
+	out.pos = 0;
+	out.size = dst_size;
+
+	rc = ZSTD_decompressStream(ds->stream, &out, &in);
+
+	*src_processed = in.pos;
+	*dst_processed = out.pos;
+	if (ZSTD_isError(rc))
+	{
+		ds->error = ZSTD_getErrorName(rc);
+		return ZS_DECOMPRESS_ERROR;
+	}
+
+	if (rc == 0)
+	{
+		return ZS_STREAM_END;
+	}
+
+	if (out.pos == out.size)
+	{
+		/*
+		 * if `output.pos == output.size`, there might be some data left
+		 * within internal buffers
+		 */
+		return ZS_DATA_PENDING;
+	}
+	return ZS_OK;
+}
+
+static ssize_t
+zstd_compress(void *c_stream, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	ZPQ_ZSTD_CStream *cs = (ZPQ_ZSTD_CStream *) c_stream;
+	ZSTD_inBuffer in;
+	ZSTD_outBuffer out;
+
+	in.src = src;
+	in.pos = 0;
+	in.size = src_size;
+
+	out.dst = dst;
+	out.pos = 0;
+	out.size = dst_size;
+
+	if (in.pos < src_size)		/* Has something to compress in input buffer */
+	{
+		size_t		rc = ZSTD_compressStream(cs->stream, &out, &in);
+
+		*dst_processed = out.pos;
+		*src_processed = in.pos;
+		if (ZSTD_isError(rc))
+		{
+			cs->error = ZSTD_getErrorName(rc);
+			return ZS_COMPRESS_ERROR;
+		}
+	}
+
+	if (in.pos == src_size)		/* All data is compressed: flush internal zstd
+								 * buffer */
+	{
+		size_t		tx_not_flushed = ZSTD_flushStream(cs->stream, &out);
+
+		*dst_processed = out.pos;
+		if (tx_not_flushed > 0)
+		{
+			return ZS_DATA_PENDING;
+		}
+	}
+
+	return ZS_OK;
+}
+
+static ssize_t
+zstd_end(void *c_stream, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	ZPQ_ZSTD_CStream *cs = (ZPQ_ZSTD_CStream *) c_stream;
+	ZSTD_outBuffer output;
+
+	output.dst = dst;
+	output.pos = 0;
+	output.size = dst_size;
+
+	size_t		tx_not_flushed;
+
+	do
+	{
+		tx_not_flushed = ZSTD_endStream(cs->stream, &output);
+	} while ((tx_not_flushed > 0) && (output.pos < output.size));
+
+	*dst_processed = output.pos;
+
+	if (tx_not_flushed > 0)
+	{
+		return ZS_DATA_PENDING;
+	}
+	return ZS_OK;
+}
+
+static void
+zstd_free_compressor(void *c_stream)
+{
+	ZPQ_ZSTD_CStream *cs = (ZPQ_ZSTD_CStream *) c_stream;
+
+	if (cs != NULL)
+	{
+		ZSTD_freeCStream(cs->stream);
+		free(cs);
+	}
+}
+
+static void
+zstd_free_decompressor(void *d_stream)
+{
+	ZPQ_ZSTD_DStream *ds = (ZPQ_ZSTD_DStream *) d_stream;
+
+	if (ds != NULL)
+	{
+		ZSTD_freeDStream(ds->stream);
+		free(ds);
+	}
+}
+
+static char const *
+zstd_compress_error(void *c_stream)
+{
+	ZPQ_ZSTD_CStream *cs = (ZPQ_ZSTD_CStream *) c_stream;
+
+	return cs->error;
+}
+
+static char const *
+zstd_decompress_error(void *d_stream)
+{
+	ZPQ_ZSTD_DStream *ds = (ZPQ_ZSTD_DStream *) d_stream;
+
+	return ds->error;
+}
+
+static char const *
+zstd_name(void)
+{
+	return "zstd";
+}
+
+#endif
+
+#if HAVE_LIBZ
+
+#include <stdlib.h>
+#include <zlib.h>
+
+
+static void *
+zlib_create_compressor(int level)
+{
+	int			rc;
+	z_stream   *c_stream = (z_stream *) malloc(sizeof(z_stream));
+
+	memset(c_stream, 0, sizeof(*c_stream));
+	rc = deflateInit(c_stream, level);
+	if (rc != Z_OK)
+	{
+		free(c_stream);
+		return NULL;
+	}
+	return c_stream;
+}
+
+static void *
+zlib_create_decompressor()
+{
+	int			rc;
+	z_stream   *d_stream = (z_stream *) malloc(sizeof(z_stream));
+
+	memset(d_stream, 0, sizeof(*d_stream));
+	rc = inflateInit(d_stream);
+	if (rc != Z_OK)
+	{
+		free(d_stream);
+		return NULL;
+	}
+	return d_stream;
+}
+
+static ssize_t
+zlib_decompress(void *d_stream, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	z_stream   *ds = (z_stream *) d_stream;
+	int			rc;
+
+	ds->next_in = (Bytef *) src;
+	ds->avail_in = src_size;
+	ds->next_out = (Bytef *) dst;
+	ds->avail_out = dst_size;
+
+	rc = inflate(ds, Z_SYNC_FLUSH);
+	*src_processed = src_size - ds->avail_in;
+	*dst_processed = dst_size - ds->avail_out;
+
+	if (rc == Z_STREAM_END)
+	{
+		return ZS_STREAM_END;
+	}
+	if (rc != Z_OK && rc != Z_BUF_ERROR)
+	{
+		return ZS_DECOMPRESS_ERROR;
+	}
+
+	return ZS_OK;
+}
+
+static ssize_t
+zlib_compress(void *c_stream, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	z_stream   *cs = (z_stream *) c_stream;
+	int			rc;
+	unsigned	deflate_pending = 0;
+
+
+	cs->next_out = (Bytef *) dst;
+	cs->avail_out = dst_size;
+	cs->next_in = (Bytef *) src;
+	cs->avail_in = src_size;
+
+	rc = deflate(cs, Z_SYNC_FLUSH);
+	Assert(rc == Z_OK);
+	*dst_processed = dst_size - cs->avail_out;
+	*src_processed = src_size - cs->avail_in;
+
+	deflatePending(cs, &deflate_pending, Z_NULL);	/* check if any data left
+													 * in deflate buffer */
+	if (deflate_pending > 0)
+	{
+		return ZS_DATA_PENDING;
+	}
+	return ZS_OK;
+}
+
+
+static ssize_t
+zlib_end(void *c_stream, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	z_stream   *cs = (z_stream *) c_stream;
+	int			rc;
+
+	cs->next_out = (Bytef *) dst;
+	cs->avail_out = dst_size;
+	cs->next_in = NULL;
+	cs->avail_in = 0;
+
+	rc = deflate(cs, Z_STREAM_END);
+	Assert(rc == Z_OK || rc == Z_STREAM_END);
+	*dst_processed = dst_size - cs->avail_out;
+	if (rc == Z_STREAM_END)
+	{
+		return ZS_OK;
+	}
+
+	return ZS_DATA_PENDING;
+}
+
+static void
+zlib_free_compressor(void *c_stream)
+{
+	z_stream   *cs = (z_stream *) c_stream;
+
+	if (cs != NULL)
+	{
+		deflateEnd(cs);
+		free(cs);
+	}
+}
+
+static void
+zlib_free_decompressor(void *d_stream)
+{
+	z_stream   *ds = (z_stream *) d_stream;
+
+	if (ds != NULL)
+	{
+		inflateEnd(ds);
+		free(ds);
+	}
+}
+
+static char const *
+zlib_error(void *stream)
+{
+	z_stream   *zs = (z_stream *) stream;
+
+	return zs->msg;
+}
+
+static char const *
+zlib_name(void)
+{
+	return "zlib";
+}
+
+#endif
+
+static char const *
+no_compression_name(void)
+{
+	return NULL;
+}
+
+/*
+ * Array with all supported compression algorithms.
+ */
+static ZAlgorithm const zpq_algorithms[] =
+{
+#if HAVE_LIBZSTD
+	{zstd_name, zstd_create_compressor, zstd_create_decompressor, zstd_decompress, zstd_compress, zstd_free_compressor, zstd_free_decompressor, zstd_compress_error, zstd_decompress_error, zstd_end},
+#endif
+#if HAVE_LIBZ
+	{zlib_name, zlib_create_compressor, zlib_create_decompressor, zlib_decompress, zlib_compress, zlib_free_compressor, zlib_free_decompressor, zlib_error, zlib_error, zlib_end},
+#endif
+	{no_compression_name}
+};
+
+static ssize_t
+zpq_init_compressor(ZStream * zs, int c_alg_impl, int c_level)
+{
+	zs->c_algorithm = &zpq_algorithms[c_alg_impl];
+	zs->c_stream = zpq_algorithms[c_alg_impl].create_compressor(c_level);
+	if (zs->c_stream == NULL)
+	{
+		return -1;
+	}
+	return 0;
+}
+
+static ssize_t
+zpq_init_decompressor(ZStream * zs, int d_alg_impl)
+{
+	zs->d_algorithm = &zpq_algorithms[d_alg_impl];
+	zs->d_stream = zpq_algorithms[d_alg_impl].create_decompressor();
+	if (zs->d_stream == NULL)
+	{
+		return -1;
+	}
+	return 0;
+}
+
+/*
+ * Index of used compression algorithm in zpq_algorithms array.
+ */
+ZStream *
+zs_create(int c_alg_impl, int c_level, int d_alg_impl)
+{
+	ZStream    *zs = (ZStream *) malloc(sizeof(ZStream));
+
+	zs->tx_not_flushed = false;
+	zs->rx_not_flushed = false;
+
+	if (zpq_init_compressor(zs, c_alg_impl, c_level) || zpq_init_decompressor(zs, d_alg_impl))
+	{
+		free(zs);
+		return NULL;
+	}
+
+	return zs;
+}
+
+ssize_t
+zs_read(ZStream * zs, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	*src_processed = 0;
+	*dst_processed = 0;
+
+	ssize_t		rc = zs->d_algorithm->decompress(zs->d_stream,
+												 src, src_size, src_processed,
+												 dst, dst_size, dst_processed);
+
+	zs->rx_not_flushed = false;
+	if (rc == ZS_DATA_PENDING)
+	{
+		zs->rx_not_flushed = true;
+		return ZS_OK;
+	}
+
+	if (rc != ZS_OK && rc != ZS_STREAM_END)
+	{
+		return ZS_DECOMPRESS_ERROR;
+	}
+
+	return rc;
+}
+
+ssize_t
+zs_write(ZStream * zs, void const *buf, size_t size, size_t *processed, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	*processed = 0;
+	*dst_processed = 0;
+
+	ssize_t		rc = zs->c_algorithm->compress(zs->c_stream,
+											   buf, size, processed,
+											   dst, dst_size, dst_processed);
+
+	zs->tx_not_flushed = false;
+	if (rc == ZS_DATA_PENDING)
+	{
+		zs->tx_not_flushed = true;
+		return ZS_OK;
+	}
+	if (rc != ZS_OK)
+	{
+		return ZS_COMPRESS_ERROR;
+	}
+
+	return rc;
+}
+
+void
+zs_free(ZStream * zs)
+{
+	if (zs)
+	{
+		if (zs->c_stream)
+		{
+			zs->c_algorithm->free_compressor(zs->c_stream);
+		}
+		if (zs->d_stream)
+		{
+			zs->d_algorithm->free_decompressor(zs->d_stream);
+		}
+		free(zs);
+	}
+}
+
+ssize_t
+zs_end(ZStream * zs, void *dst, size_t dst_size, size_t *dst_processed)
+{
+	*dst_processed = 0;
+
+	ssize_t		rc = zs->c_algorithm->end_compression(zs->c_stream, dst, dst_size, dst_processed);
+
+	zs->tx_not_flushed = false;
+	if (rc == ZS_DATA_PENDING)
+	{
+		zs->tx_not_flushed = true;
+		return ZS_OK;
+	}
+	if (rc != ZS_OK)
+	{
+		return ZS_COMPRESS_ERROR;
+	}
+
+	return rc;
+}
+
+char const *
+zs_compress_error(ZStream * zs)
+{
+	return zs->c_algorithm->compress_error(zs->c_stream);
+}
+
+char const *
+zs_decompress_error(ZStream * zs)
+{
+	return zs->d_algorithm->decompress_error(zs->d_stream);
+}
+
+bool
+zs_buffered_rx(ZStream * zs)
+{
+	return zs ? zs->rx_not_flushed : 0;
+}
+
+bool
+zs_buffered_tx(ZStream * zs)
+{
+	return zs ? zs->tx_not_flushed : 0;
+}
+
+/*
+ * Get list of the supported algorithms.
+ */
+char	  **
+zs_get_supported_algorithms(void)
+{
+	size_t		n_algorithms = sizeof(zpq_algorithms) / sizeof(*zpq_algorithms);
+	char	  **algorithm_names = malloc(n_algorithms * sizeof(char *));
+
+	for (size_t i = 0; i < n_algorithms; i++)
+	{
+		algorithm_names[i] = (char *) zpq_algorithms[i].name();
+	}
+
+	return algorithm_names;
+}
+
+char const *
+zs_compress_algorithm_name(ZStream * zs)
+{
+	return zs ? zs->c_algorithm->name() : NULL;
+}
+
+char const *
+zs_decompress_algorithm_name(ZStream * zs)
+{
+	return zs ? zs->d_algorithm->name() : NULL;
+}

--- a/src/include/common/z_stream.h
+++ b/src/include/common/z_stream.h
@@ -1,0 +1,90 @@
+/*
+ * z_stream.h
+ *     Streaming compression
+ */
+
+
+#ifndef Z_STREAM_H
+#define Z_STREAM_H
+
+#include <stdlib.h>
+
+#define ZS_OK (0)
+#define ZS_IO_ERROR (-1)
+#define ZS_DECOMPRESS_ERROR (-2)
+#define ZS_COMPRESS_ERROR (-3)
+#define ZS_STREAM_END (-4)
+#define ZS_DATA_PENDING (-5)
+
+struct ZStream;
+typedef struct ZStream ZStream;
+
+#endif
+
+/*
+ * Create compression stream with rx/tx function for reading/sending compressed data.
+ * c_alg_impl: index of chosen compression algorithm
+ * c_level: compression c_level
+ * d_alg_impl: index of chosen decompression algorithm
+ */
+extern ZStream * zs_create(int c_alg_impl, int c_level, int d_alg_impl);
+
+/*
+ * Read up to "size" raw (decompressed) bytes.
+ * Returns number of decompressed bytes or error code.
+ * Error code is either ZS_DECOMPRESS_ERROR or error code returned by the rx function.
+ */
+extern ssize_t zs_read(ZStream * zs, void const *src, size_t src_size, size_t *src_processed, void *dst, size_t dst_size, size_t *dst_processed);
+
+/*
+ * Write up to "size" raw (decompressed) bytes.
+ * Returns number of written raw bytes or error code.
+ * Error code is either ZS_COMPRESS_ERROR or error code returned by the tx function.
+ * In the last case number of bytes written is stored in *processed.
+ */
+extern ssize_t zs_write(ZStream * zs, void const *buf, size_t size, size_t *processed, void *dst, size_t dst_size, size_t *dst_processed);
+
+/*
+ * Get decompressor error message.
+ */
+extern char const *zs_decompress_error(ZStream * zs);
+
+/*
+ * Get compressor error message.
+ */
+extern char const *zs_compress_error(ZStream * zs);
+
+/*
+ * Return true if non-flushed data might left in internal rx decompression buffer.
+ */
+extern bool zs_buffered_rx(ZStream * zs);
+
+/*
+ * Return true if non-flushed data might left in internal tx compression buffer.
+ */
+extern bool zs_buffered_tx(ZStream * zs);
+
+/*
+ * End the compression stream.
+ */
+extern ssize_t zs_end(ZStream * zs, void *dst, size_t dst_size, size_t *dst_processed);
+
+/*
+ * Free stream created by zs_create function.
+ */
+extern void zs_free(ZStream * zs);
+
+/*
+ * Get the name of chosen compression algorithm.
+ */
+extern char const *zs_compress_algorithm_name(ZStream * zs);
+
+/*
+ * Get the name of chosen decompression algorithm.
+ */
+extern char const *zs_decompress_algorithm_name(ZStream * zs);
+
+/*
+  Returns zero terminated array with compression algorithms names
+*/
+extern char **zs_get_supported_algorithms(void);

--- a/src/include/common/zpq_stream.h
+++ b/src/include/common/zpq_stream.h
@@ -3,17 +3,13 @@
  *     Streaming compression for libpq
  */
 
+#include "z_stream.h"
+
 #ifndef ZPQ_STREAM_H
 #define ZPQ_STREAM_H
 
 #include <stdlib.h>
 
-#define ZPQ_OK (0)
-#define ZPQ_IO_ERROR (-1)
-#define ZPQ_DECOMPRESS_ERROR (-2)
-#define ZPQ_COMPRESS_ERROR (-3)
-#define ZPQ_STREAM_END (-4)
-#define ZPQ_DATA_PENDING (-5)
 
 #define ZPQ_DEFAULT_COMPRESSION_LEVEL (1)
 
@@ -22,6 +18,9 @@ typedef struct ZpqStream ZpqStream;
 
 typedef ssize_t (*zpq_tx_func) (void *arg, void const *data, size_t size);
 typedef ssize_t (*zpq_rx_func) (void *arg, void *data, size_t size);
+
+
+#endif
 
 /*
  * Create compression stream with rx/tx function for reading/sending compressed data.
@@ -34,61 +33,49 @@ typedef ssize_t (*zpq_rx_func) (void *arg, void *data, size_t size);
  * rx_data: received data (compressed data already fetched from input stream)
  * rx_data_size: size of data fetched from input stream
  */
-extern ZpqStream  *zpq_create(int c_alg_impl, int c_level, int d_alg_impl, zpq_tx_func tx_func, zpq_rx_func rx_func, void *arg, char *rx_data, size_t rx_data_size);
+extern ZpqStream * zpq_create(int c_alg_impl, int c_level, int d_alg_impl, zpq_tx_func tx_func, zpq_rx_func rx_func, void *arg, char *rx_data, size_t rx_data_size);
 
 /*
- * Read up to "size" raw (decompressed) bytes.
+ * Write up to "src_size" raw (decompressed) bytes.
+ * Returns number of written raw bytes or error code.
+ * Error code is either ZPQ_COMPRESS_ERROR or error code returned by the tx function.
+ * In the last case number of bytes written is stored in *src_processed.
+ */
+extern ssize_t zpq_write(ZpqStream * zpq, void const *src, size_t src_size, size_t *src_processed);
+
+/*
+ * Read up to "dst_size" raw (decompressed) bytes.
  * Returns number of decompressed bytes or error code.
  * Error code is either ZPQ_DECOMPRESS_ERROR or error code returned by the rx function.
  */
-extern ssize_t		zpq_read(ZpqStream * zs, void *buf, size_t size);
+extern ssize_t zpq_read(ZpqStream * zpq, void *dst, size_t dst_size);
 
 /*
- * Write up to "size" raw (decompressed) bytes.
- * Returns number of written raw bytes or error code.
- * Error code is either ZPQ_COMPRESS_ERROR or error code returned by the tx function.
- * In the last case number of bytes written is stored in *processed.
+ * Return true if non-flushed data left in internal rx decompression buffer.
  */
-extern ssize_t		zpq_write(ZpqStream * zs, void const *buf, size_t size, size_t *processed);
+extern bool zpq_buffered_rx(ZpqStream * zpq);
+
+/*
+ * Return true if non-flushed data left in internal tx compression buffer.
+ */
+extern bool zpq_buffered_tx(ZpqStream * zpq);
+
+/*
+ * Free stream created by zs_create function.
+ */
+extern void zpq_free(ZpqStream * zpq);
 
 /*
  * Get decompressor error message.
  */
-extern char const *zpq_decompress_error(ZpqStream * zs);
+extern char const *zpq_decompress_error(ZpqStream * zpq);
 
 /*
  * Get compressor error message.
  */
-extern char const *zpq_compress_error(ZpqStream * zs);
-
-/*
- * Return an estimated amount of data in internal rx decompression buffer.
- */
-extern size_t		zpq_buffered_rx(ZpqStream * zs);
-
-/*
- * Return an estimated amount of data in internal tx compression buffer.
- */
-extern size_t		zpq_buffered_tx(ZpqStream * zs);
-
-/*
- * Free stream created by zpq_create function.
- */
-extern void		zpq_free(ZpqStream * zs);
+extern char const *zpq_compress_error(ZpqStream * zpq);
 
 /*
  * Get the name of chosen compression algorithm.
  */
-extern char const *zpq_compress_algorithm_name(ZpqStream * zs);
-
-/*
- * Get the name of chosen decompression algorithm.
- */
-extern char const *zpq_decompress_algorithm_name(ZpqStream * zs);
-
-/*
-  Returns zero terminated array with compression algorithms names
-*/
-extern char	  **zpq_get_supported_algorithms(void);
-
-#endif
+extern char const *zpq_compress_algorithm_name(ZpqStream * zpq);

--- a/src/include/common/zpq_stream.h
+++ b/src/include/common/zpq_stream.h
@@ -12,7 +12,7 @@
 
 
 #define ZPQ_DEFAULT_COMPRESSION_LEVEL (1)
-
+#define ZPQ_INCOMPLETE_HEADER (-6)
 struct ZpqStream;
 typedef struct ZpqStream ZpqStream;
 

--- a/src/interfaces/libpq/exports.txt
+++ b/src/interfaces/libpq/exports.txt
@@ -179,3 +179,4 @@ PQgetgssctx               176
 PQsetSSLKeyPassHook_OpenSSL         177
 PQgetSSLKeyPassHook_OpenSSL         178
 PQdefaultSSLKeyPassHook_OpenSSL     179
+PQreadPending                       180

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2157,12 +2157,6 @@ connectDBComplete(PGconn *conn)
 				return 1;		/* success! */
 
 			case PGRES_POLLING_READING:
-			    /* if there is some buffered RX data in ZpqStream
-			     * then don't proceed to pqWaitTimed */
-			    if (zpq_buffered_rx(conn->zstream)) {
-			        break;
-			    }
-
 				ret = pqWaitTimed(1, 0, conn, finish_time);
 				if (ret == -1)
 				{

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -464,8 +464,8 @@ void
 pqDropConnection(PGconn *conn, bool flushInput)
 {
 	/* Release compression streams */
-	zpq_free(conn->zstream);
-	conn->zstream = NULL;
+	zpq_free(conn->zpqStream);
+	conn->zpqStream = NULL;
 
 	/* Drop any SSL state */
 	pqsecure_close(conn);
@@ -3234,10 +3234,11 @@ keep_going:						/* We will come back to here until there is
 						return PGRES_POLLING_READING;
 					}
 
-					if (beresp == 'z') /* Switch on compression */
+					if (beresp == 'z')	/* Switch on compression */
 					{
-						int index;
-						char resp;
+						int			index;
+						char		resp;
+
 						/* Read message length word */
 						if (pqGetInt(&msgLength, 4, conn))
 						{
@@ -3248,40 +3249,43 @@ keep_going:						/* We will come back to here until there is
 						{
 							appendPQExpBuffer(&conn->errorMessage,
 											  libpq_gettext(
-												  "expected compression algorithm specification message length is 5 bytes, but %d is received\n"),
+															"expected compression algorithm specification message length is 5 bytes, but %d is received\n"),
 											  msgLength);
 							goto error_return;
 						}
 						pqGetc(&resp, conn);
 						index = resp;
-						if (index == (char)-1)
+						if (index == (char) -1)
 						{
 							appendPQExpBuffer(&conn->errorMessage,
 											  libpq_gettext(
-												  "server does not support requested compression algorithms %s\n"),
+															"server does not support requested compression algorithms %s\n"),
 											  conn->compression);
 							goto error_return;
 						}
-						if ((unsigned)index >= conn->n_compressors)
+						if ((unsigned) index >= conn->n_compressors)
 						{
 							appendPQExpBuffer(&conn->errorMessage,
 											  libpq_gettext(
-												  "server returns incorrect compression aslogirhm  index: %d\n"),
+															"server returns incorrect compression aslogirhm  index: %d\n"),
 											  index);
 							goto error_return;
 						}
-						Assert(!conn->zstream);
-						conn->zstream = zpq_create(conn->compressors[index].impl,
-												   conn->compressors[index].level,
-                                                   conn->compressors[index].impl,
-												   (zpq_tx_func)pqsecure_write, (zpq_rx_func)pqsecure_read, conn,
-												   &conn->inBuffer[conn->inCursor], conn->inEnd-conn->inCursor);
-						if (!conn->zstream)
+						Assert(!conn->zpqStream);
+						conn->zpqStream = zpq_create(conn->compressors[index].impl,
+													 conn->compressors[index].level,
+													 conn->compressors[index].impl,
+													 (zpq_tx_func) pqsecure_write, (zpq_rx_func) pqsecure_read,
+													 conn,
+													 &conn->inBuffer[conn->inCursor],
+													 conn->inEnd - conn->inCursor);
+						if (!conn->zpqStream)
 						{
-							char** supported_algorithms = zpq_get_supported_algorithms();
+							char	  **supported_algorithms = zs_get_supported_algorithms();
+
 							appendPQExpBuffer(&conn->errorMessage,
 											  libpq_gettext(
-												  "failed to initialize compressor %s\n"),
+															"failed to initialize compressor %s\n"),
 											  supported_algorithms[conn->compressors[index].impl]);
 							free(supported_algorithms);
 							goto error_return;
@@ -3289,13 +3293,15 @@ keep_going:						/* We will come back to here until there is
 						/* reset buffer */
 						conn->inStart = conn->inCursor = conn->inEnd = 0;
 					}
-					else if (conn->n_compressors != 0 && beresp == 'v') /* negotiate protocol version */
+					else if (conn->n_compressors != 0 && beresp == 'v') /* negotiate protocol
+																		 * version */
 					{
 						appendPQExpBuffer(&conn->errorMessage,
 										  libpq_gettext(
-											  "server is not supporting libpq compression\n"));
+														"server is not supporting libpq compression\n"));
 						goto error_return;
-					} else
+					}
+					else
 						break;
 				}
 

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -1810,9 +1810,7 @@ PQgetResult(PGconn *conn)
 		 * EOF indication.  We expect therefore that this won't result in any
 		 * undue delay in reporting a previous write failure.)
 		 */
-		if (flushResult || (zpq_buffered_rx(conn->zstream) == 0 &&
-			pqWait(true, false, conn)) ||
-			pqReadData(conn) < 0)
+		if (flushResult || pqWait(true, false, conn) || pqReadData(conn) < 0)
 		{
 			/*
 			 * conn->errorMessage has been set by pqWait or pqReadData. We
@@ -3283,6 +3281,12 @@ int
 PQflush(PGconn *conn)
 {
 	return pqFlush(conn);
+}
+
+int
+PQreadPending(PGconn *conn)
+{
+	return pqReadPending(conn);
 }
 
 

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -1679,7 +1679,7 @@ pqGetCopyData3(PGconn *conn, char **buffer, int async)
 			if (async)
 				return 0;
 			/* Need to load more data */
-			if ((zpq_buffered_rx(conn->zstream) == 0 && pqWait(true, false, conn)) ||
+			if (pqWait(true, false, conn) ||
 				pqReadData(conn) < 0)
 				return -2;
 			continue;
@@ -1737,7 +1737,7 @@ pqGetline3(PGconn *conn, char *s, int maxlen)
 	while ((status = PQgetlineAsync(conn, s, maxlen - 1)) == 0)
 	{
 		/* need to load more data */
-		if ((zpq_buffered_rx(conn->zstream) == 0 && pqWait(true, false, conn)) ||
+		if (pqWait(true, false, conn) ||
 			pqReadData(conn) < 0)
 		{
 			*s = '\0';
@@ -1975,7 +1975,7 @@ pqFunctionCall3(PGconn *conn, Oid fnid,
 		if (needInput)
 		{
 			/* Wait for some data to arrive (or for the channel to close) */
-			if ((zpq_buffered_rx(conn->zstream) == 0 && pqWait(true, false, conn)) ||
+			if (pqWait(true, false, conn) ||
 				pqReadData(conn) < 0)
 				break;
 		}

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2146,17 +2146,17 @@ pqBuildStartupPacket3(PGconn *conn, int *packetlen,
  * and is used during handshake when a compression acknowledgment response is received from the server.
  */
 static bool
-build_compressors_list(PGconn *conn, char** client_compressors, bool build_descriptors)
+build_compressors_list(PGconn *conn, char **client_compressors, bool build_descriptors)
 {
-	char** supported_algorithms = zpq_get_supported_algorithms();
-	char* value = conn->compression;
-	int n_supported_algorithms;
-	int total_len = 0;
-	int i;
+	char	  **supported_algorithms = zs_get_supported_algorithms();
+	char	   *value = conn->compression;
+	int			n_supported_algorithms;
+	int			total_len = 0;
+	int			i;
 
 	for (n_supported_algorithms = 0; supported_algorithms[n_supported_algorithms] != NULL; n_supported_algorithms++)
 	{
-		total_len += strlen(supported_algorithms[n_supported_algorithms])+1;
+		total_len += strlen(supported_algorithms[n_supported_algorithms]) + 1;
 	}
 
 	if (pg_strcasecmp(value, "true") == 0 ||
@@ -2166,7 +2166,7 @@ build_compressors_list(PGconn *conn, char** client_compressors, bool build_descr
 		pg_strcasecmp(value, "1") == 0)
 	{
 		/* Compression is enabled: choose algorithm automatically */
-		char* p;
+		char	   *p;
 
 		if (n_supported_algorithms == 0)
 		{
@@ -2177,7 +2177,7 @@ build_compressors_list(PGconn *conn, char** client_compressors, bool build_descr
 		}
 		*client_compressors = p = malloc(total_len);
 		if (build_descriptors)
-			conn->compressors = malloc(n_supported_algorithms*sizeof(pg_conn_compressor));
+			conn->compressors = malloc(n_supported_algorithms * sizeof(pg_conn_compressor));
 		for (i = 0; i < n_supported_algorithms; i++)
 		{
 			strcpy(p, supported_algorithms[i]);
@@ -2207,20 +2207,22 @@ build_compressors_list(PGconn *conn, char** client_compressors, bool build_descr
 	else
 	{
 		/* List of compression algorithms separated by commas */
-		char *src, *dst;
-		int n_suggested_algorithms = 0;
-		char* suggested_algorithms = strdup(value);
+		char	   *src,
+				   *dst;
+		int			n_suggested_algorithms = 0;
+		char	   *suggested_algorithms = strdup(value);
+
 		src = suggested_algorithms;
 		*client_compressors = dst = strdup(value);
 
 		if (build_descriptors)
-			conn->compressors = malloc(n_supported_algorithms*sizeof(pg_conn_compressor));
+			conn->compressors = malloc(n_supported_algorithms * sizeof(pg_conn_compressor));
 
 		while (*src != '\0')
 		{
-			char* sep = strchr(src, ',');
-			char* col;
-			int compression_level = ZPQ_DEFAULT_COMPRESSION_LEVEL;
+			char	   *sep = strchr(src, ',');
+			char	   *col;
+			int			compression_level = ZPQ_DEFAULT_COMPRESSION_LEVEL;
 
 			if (sep != NULL)
 				*sep = '\0';
@@ -2231,11 +2233,11 @@ build_compressors_list(PGconn *conn, char** client_compressors, bool build_descr
 			if (col != NULL)
 			{
 				*col = '\0';
-				if (sscanf(col+1, "%d", &compression_level) != 1 && !build_descriptors)
+				if (sscanf(col + 1, "%d", &compression_level) != 1 && !build_descriptors)
 				{
 					fprintf(stderr,
 							libpq_gettext("WARNING: invalid compression level %s in compression option '%s'\n"),
-							col+1, value);
+							col + 1, value);
 					return false;
 				}
 			}
@@ -2255,7 +2257,7 @@ build_compressors_list(PGconn *conn, char** client_compressors, bool build_descr
 				}
 			}
 			if (sep)
-				src = sep+1;
+				src = sep + 1;
 			else
 				break;
 		}
@@ -2330,8 +2332,9 @@ build_startup_packet(const PGconn *conn, char *packet,
 		ADD_STARTUP_OPTION("options", conn->pgoptions);
 	if (conn->compression && conn->compression[0])
 	{
-		char* client_compression_algorithms;
-		if (build_compressors_list((PGconn*)conn, &client_compression_algorithms, packet == NULL))
+		char	   *client_compression_algorithms;
+
+		if (build_compressors_list((PGconn *) conn, &client_compression_algorithms, packet == NULL))
 		{
 			if (client_compression_algorithms)
 			{

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -461,6 +461,9 @@ extern PGPing PQpingParams(const char *const *keywords,
 /* Force the write buffer to be written (or at least try) */
 extern int	PQflush(PGconn *conn);
 
+extern int
+			PQreadPending(PGconn *conn);
+
 /*
  * "Fast path" interface --- not really recommended for application
  * use

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -386,7 +386,7 @@ struct pg_conn
 								 * comma) */
 	pg_conn_compressor *compressors;	/* descriptors of compression
 										 * algorithms chosen by client */
-	unsigned			n_compressors;  /* size of compressors array  */
+	unsigned	n_compressors;	/* size of compressors array  */
 
 	/* Type of connection to make.  Possible values: any, read-write. */
 	char	   *target_session_attrs;
@@ -547,7 +547,7 @@ struct pg_conn
 	PQExpBufferData workBuffer; /* expansible string */
 
 	/* Compression stream */
-	ZpqStream  *zstream;
+	ZpqStream  *zpqStream;
 };
 
 /* PGcancel stores all data necessary to cancel a connection. A copy of this

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -695,6 +695,7 @@ extern int	pqWaitTimed(int forRead, int forWrite, PGconn *conn,
 						time_t finish_time);
 extern int	pqReadReady(PGconn *conn);
 extern int	pqWriteReady(PGconn *conn);
+extern int	pqReadPending(PGconn *conn);
 
 /* === in fe-secure.c === */
 

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -123,7 +123,7 @@ sub mkvcbuild
 	  config_info.c controldata_utils.c d2s.c encnames.c exec.c
 	  f2s.c file_perm.c file_utils.c hashfn.c ip.c jsonapi.c
 	  keywords.c kwlookup.c link-canary.c md5.c
-	  pg_get_line.c zpq_stream.c pg_lzcompress.c pgfnames.c psprintf.c relpath.c rmtree.c
+	  pg_get_line.c z_stream.c zpq_stream.c pg_lzcompress.c pgfnames.c psprintf.c relpath.c rmtree.c
 	  saslprep.c scram-common.c string.c stringinfo.c unicode_norm.c username.c
 	  wait_error.c wchar.c);
 


### PR DESCRIPTION
In this PR, I propose implementing the selective switchable on the fly compression. 
Also, in this pull request, I’ve made the following changes:
- extracted the general-purpose streaming compression API into the separate structure (ZStream) so it can be used in other places without tx_func and rx_func,
maybe the other compression patches can utilize it?
- made some refactoring of ZpqStream
- moved the SSL and ZPQ buffered read data checks into separate function pqReadPending

